### PR TITLE
[benchpress] Make sure that correctness_tests attribute is defined

### DIFF
--- a/benchpress/README.md
+++ b/benchpress/README.md
@@ -47,10 +47,6 @@ How benchpress works
 reference to a binary (that usually can be run with different arguments). A job
 is a specific run of that benchmark with a different configuration.  
 
-`benchpress` also has some support for running jobs that contain correctness
-tests, any metric that is a `bool` is assumed to be a 'correctness' metric and
-if `False`, will result in the job being reported as failing.
-
 Benchmark config
 ----------------
 

--- a/benchpress/benchpress/cli/commands/run.py
+++ b/benchpress/benchpress/cli/commands/run.py
@@ -55,11 +55,4 @@ class RunCommand(BenchpressCommand):
 
             history.save_job_result(job, metrics, now)
 
-            # if a correctness test failed, make it obvious
-            if False in metrics.correctness_tests().values():
-                # find which one(s) failed
-                for key, val in metrics.correctness_tests().items():
-                    if not val:
-                        logger.error('Correctness test "%s" failed', key)
-
         reporter.close()


### PR DESCRIPTION
Not all benchmarks define correctness tests this causes an
AttributeError. This fix simply checks if the metrics objects
contains the correctness_tests() method before it tries to call
it and iterate over its values.

Also, removes the redundant check for False in any of the values
since the 'in' operator will regardless iteratate over the list
of values and the inner block will still iterate again over it
to print any of the failed correctness tests.