### PR TITLE
Benchpress/gap benchmark

### DIFF
--- a/benchpress/benchmarks.yml
+++ b/benchpress/benchmarks.yml
@@ -26,3 +26,29 @@ silo:
     - latency:
         - avg_latency
 
+gapbs_bc:
+  parser: gapbs
+  path: ./benchmarks/gapbs/bc
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_bfs:
+  parser: gapbs
+  path: ./benchmarks/gapbs/bfs
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_tc:
+  parser: gapbs
+  path: ./benchmarks/gapbs/tc
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time

--- a/benchpress/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/benchpress/plugins/parsers/__init__.py
@@ -7,6 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from .fio import FioParser
+from .gapbs import GAPBSParser
 from .generic import JSONParser
 from .ltp import LtpParser
 from .returncode import ReturncodeParser
@@ -16,6 +17,7 @@ from .silo import SiloParser
 
 def register_parsers(factory):
     factory.register('fio', FioParser)
+    factory.register('gapbs', GAPBSParser)
     factory.register('json', JSONParser)
     factory.register('ltp', LtpParser)
     factory.register('returncode', ReturncodeParser)

--- a/benchpress/benchpress/plugins/parsers/gapbs.py
+++ b/benchpress/benchpress/plugins/parsers/gapbs.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import re
+
+from benchpress.lib.parser import Parser
+
+TIME_REGEX = r'(\w+\sTime):\s+(\d+\.?\d*)'
+
+
+class GAPBSParser(Parser):
+
+    def parse(self, stdout, stderr, returncode):
+        output = ' '.join(stdout)
+        metrics = {}
+        times = re.findall(TIME_REGEX, output)
+        for t in times:
+            key = self.snakeify_name(t[0])
+            metrics[key] = float(t[1])
+        return metrics
+
+    def snakeify_name(self, s):
+        return '_'.join(s.strip().lower().split())

--- a/benchpress/install_gapbs.sh
+++ b/benchpress/install_gapbs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+GAP_GIT_REPO="https://github.com/sbeamer/gapbs.git"
+GAP_GIT_TAG="tags/v1.1"
+
+BENCHMARKS_DIR="$(pwd)/benchmarks/gapbs"
+mkdir -p "$BENCHMARKS_DIR"
+
+rm -rf build
+mkdir -p build
+cd build
+
+git clone "$GAP_GIT_REPO"
+cd gapbs
+git checkout -b gapbs_benchpress "$GAP_GIT_TAG"
+make
+
+mv tc sssp pr converter cc bfs bc "$BENCHMARKS_DIR"
+cd ../../
+rm -rf build
+
+echo "GAP benchmark suite installed into ${BENCHMARKS_DIR}"

--- a/benchpress/jobs/jobs.yml
+++ b/benchpress/jobs/jobs.yml
@@ -1,5 +1,5 @@
 - benchmark: schbench
-  name: schbench default 
+  name: schbench default
   description: defaults for schbench
   args:
     message-threads: 2
@@ -72,3 +72,23 @@
     scale-factor: 1
     runtime: 1
 
+- benchmark: gapbs_bc
+  name: gapbs_bc
+  description: GAP bc benchmark
+  args:
+    - -u 21
+    - -n 1
+
+- benchmark: gapbs_bfs
+  name: gapbs_bfs
+  description: GAP bfs benchmark
+  args:
+    - -u 21
+    - -n 1
+
+- benchmark: gapbs_tc
+  name: gapbs_tc
+  description: GAP tc benchmark
+  args:
+    - -u 21
+    - -n 1

--- a/benchpress/tests/test_gapbs_parser.py
+++ b/benchpress/tests/test_gapbs_parser.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import unittest
+
+from benchpress.plugins.parsers.gapbs import GAPBSParser
+
+
+class TestGAPBSParser(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = GAPBSParser()
+
+    def test_bc_sample_output(self):
+        output = [
+            'Generate Time:       0.41289',
+            'Build Time:          1.89460',
+            'Graph has 1048576 nodes and 16776968 undirected edges for degree: 15',
+            '    a                0.00035',
+            'source: 209629',
+            '    b                0.45253',
+            '    p                0.31504',
+            'Trial Time:          0.76991',
+            'Average Time:        0.76991',
+        ]
+        metrics = self.parser.parse(output, None, 0)
+        self.assertDictEqual({
+                'generate_time': 0.41289,
+                'build_time': 1.89460,
+                'trial_time': 0.76991,
+                'average_time': 0.76991,
+            }, metrics)
+
+    def test_bfs_sample_ouput(self):
+        output = [
+            'Generate Time:       0.41075',
+            'Build Time:          1.89220',
+            'Graph has 1048576 nodes and 16776968 undirected edges for degree: 15',
+            'Source:               209629',
+            '    i                0.00086',
+            '   td         29     0.00003',
+            '   td        872     0.00002',
+            '   td      27534     0.00049',
+            '   td     579473     0.01030',
+            '    e                0.00445',
+            '   bu     440667     0.01020',
+            '   bu          0     0.00044',
+            '    c                0.00073',
+            'Trial Time:          0.02800',
+            'Average Time:        0.02800',
+        ]
+        metrics = self.parser.parse(output, None, 0)
+        self.assertDictEqual({
+                'generate_time': 0.41075,
+                'build_time': 1.89220,
+                'trial_time': 0.02800,
+                'average_time': 0.02800,
+            }, metrics)
+
+    def test_tc_sample_output(self):
+        output = [
+            'Generate Time:       0.40949',
+            'Build Time:          1.88401',
+            'Graph has 1048576 nodes and 16776968 undirected edges for degree: 15',
+            'Trial Time:          2.45414',
+            'Average Time:        2.45414',
+        ]
+        metrics = self.parser.parse(output, None, 0)
+        self.assertDictEqual({
+                'generate_time': 0.40949,
+                'build_time': 1.88401,
+                'trial_time': 2.45414,
+                'average_time': 2.45414,
+            }, metrics)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds GAP benchmarking suite to Benchpress

Actual output of running benchmark through Benchpress:

@adhanotia Please review, but don't merge.

```
$ python3.6 ./benchpress_cli.py -b benchmarks.yml -j jobs/jobs.yml run gapbs_tc
Will run 1 job(s)
Running "gapbs_tc": GAP tc benchmark
{
  "average_time": 4.93834,
  "build_time": 4.6289,
  "generate_time": 0.81266,
  "trial_time": 4.93834
}
```
```
$ python3.6 ./benchpress_cli.py -b benchmarks.yml -j jobs/jobs.yml run gapbs_bc
Will run 1 job(s)
Running "gapbs_bc": GAP bc benchmark
{
  "average_time": 1.83989,
  "build_time": 4.41607,
  "generate_time": 0.72591,
  "trial_time": 1.83989
}
```
```
$ python3.6 ./benchpress_cli.py -b benchmarks.yml -j jobs/jobs.yml run gapbs_bfs
Will run 1 job(s)
Running "gapbs_bfs": GAP bfs benchmark
{
  "average_time": 0.05413,
  "build_time": 4.53836,
  "generate_time": 0.77409,
  "trial_time": 0.05413
}
```